### PR TITLE
Added fkmerge2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ CXXFLAGS = 	$(PRJCXXFLAGS)
 LDLIBS   =  ./src/libac_core.a $(PRJLDFLAGS)
 
 VPATH=./src
-MAIN = apfel_comb src/cfac_scale 
+MAIN = apfel_comb src/cfac_scale src/fkmerge2
 DEV = appl_optgrid ftdy_hcx
 
 .PHONY: all dev core clean
-	
+
 all: core $(MAIN) database
 dev: core $(DEV)
 

--- a/mergecommon.py
+++ b/mergecommon.py
@@ -64,7 +64,7 @@ def mergegrid(target, source, thID, cur):
     if os.path.isfile(mergeTarget) == True:
         print(target + bcolors.OKGREEN + " is already merged" + bcolors.ENDC)
     elif len(missing_subgrids) == 0:
-        os.system("FKmerge2 " +mergeTarget + ' ' + mergeConstituents)
+        os.system("fkmerge2 " +mergeTarget + ' ' + mergeConstituents)
         print(target + bcolors.OKGREEN + " successfully generated!" + bcolors.ENDC)
     else:
         for missing in missing_subgrids:

--- a/src/fkmerge2.cc
+++ b/src/fkmerge2.cc
@@ -1,0 +1,80 @@
+// fkmerge2: Merge FK tables
+// Author: Nathan Hartland,  n.p.hartland@vu.nl
+
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <sstream>
+#include <cstdlib>
+#include <fstream>
+#include <cmath>
+
+#include "NNPDF/fastkernel.h"
+#include "NNPDF/fkgenerator.h"
+#include "NNPDF/exceptions.h"
+
+using namespace std;
+using NNPDF::FKHeader;
+
+/**
+ * \param argv the filename containing the configuration
+ */
+int main(int argc, char **argv)
+{
+  if (argc < 3)
+  {
+     std::cout << "Usage: "<< argv[0]<<" [TargetFK] [FK table 1] ... [FK table N]"<<std::endl;
+     exit(1);
+  }
+
+  NNPDF::SetVerbosity(0);
+
+  // Init base FKHeader
+  FKHeader header(argv[2]); header.ResetFlavourMap();
+  std::stringstream IO; header.Print(IO);
+  NNPDF::FKGenerator mergeFK( IO );
+
+  for (int itab = 2; itab < argc; itab++)
+  {
+     NNPDF::FKTable iFK(argv[itab]);
+
+     // Verify equal nDat
+     if (mergeFK.GetNData() != iFK.GetNData())
+        throw NNPDF::RuntimeException("FKmerge2","Number of datapoints in merge target and constituent FK table disagrees" );
+
+     // Verify identical x-grid:
+     if (mergeFK.GetNx() != iFK.GetNx())
+        throw NNPDF::RuntimeException("FKmerge2","Number of x-points in merge target and constituent FK table disagrees" );
+     for (int ix=0; ix<mergeFK.GetNx(); ix++)
+        if (fabs(mergeFK.GetXGrid()[ix] - iFK.GetXGrid()[ix]) / mergeFK.GetXGrid()[ix] > 1E-8 )
+          throw NNPDF::RuntimeException("FKmerge2","x-grids disagree in merge target and constituent FK table" );
+
+    // Merge grids
+    if (header.GetTag<bool>(FKHeader::GRIDINFO, "HADRONIC"))
+    {
+      for (int d=0; d<mergeFK.GetNData(); d++)
+      for (int a=0; a<mergeFK.GetNx(); a++)
+      for (int b=0; b<mergeFK.GetNx(); b++)
+      for (int i=0; i<14; i++)
+      for (int j=0; j<14; j++)
+      {
+        const int iSig = iFK.GetISig(d, a, b, i, j);
+        if (iSig != -1) mergeFK.Fill(d, a, b, i, j, iFK.GetSigma()[iSig]);
+      }
+    } else
+    {
+      for (int d=0; d<mergeFK.GetNData(); d++)
+      for (int a=0; a<mergeFK.GetNx(); a++)
+      for (int i=0; i<14; i++)
+      {
+        const int iSig = iFK.GetISig(d, a, i);
+        if (iSig != -1) mergeFK.Fill(d, a, i, iFK.GetSigma()[iSig]);
+      }
+    }
+  }
+
+  mergeFK.Finalise();
+  mergeFK.Print(argv[1], true);
+
+  return 0;
+}


### PR DESCRIPTION
This PR addresses https://github.com/NNPDF/nnpdf/issues/1540 reinstates `FKmerge2` as `fkmerge2`, which was inadvertently deleted here https://github.com/NNPDF/nnpdf/commit/bed162e4a3ebc2e343f6289fc677863c552a6dd8

This is the dirtiest (but most minimal) implementation possible. The executable is generated in the `apfelcomb/src` folder and the user has to include this location to the `PATH` environmental variable. Perhaps explicit mention to this should be included in the documentation. Better installation locations can be considered, however I'm not sure if this is worth doing, in view of the fact that apfelcomb is going to be replaced.

cc @J-M-Moore